### PR TITLE
fix: Memory Store Session Webhook Update

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -27,11 +27,13 @@ module.exports = {
       // Environment variables
       env: {
         NODE_ENV: 'development',
-        PORT: 3000,
+        PORT: 3002,
+        HOST: '127.0.0.1',
       },
       env_production: {
         NODE_ENV: 'production',
-        PORT: 3000,
+        PORT: 3002,
+        HOST: '127.0.0.1',
       },
       
       // Logging

--- a/src/config/routeSchemas.ts
+++ b/src/config/routeSchemas.ts
@@ -234,6 +234,44 @@ export const MessagingSchemas = {
       },
     },
   },
+  read: {
+    tags: ['Messaging'],
+    summary: 'Mark message as read',
+    security: [{ ApiKeyAuth: [] }],
+    params: {
+      type: 'object' as const,
+      properties: {
+        sessionId: { type: 'string' as const },
+      },
+    },
+    body: {
+      type: 'object' as const,
+      required: ['remoteJid', 'messageId'],
+      properties: {
+        remoteJid: { type: 'string' as const },
+        messageId: { type: 'string' as const },
+      },
+    },
+  },
+  presence: {
+    tags: ['Messaging'],
+    summary: 'Send presence update',
+    security: [{ ApiKeyAuth: [] }],
+    params: {
+      type: 'object' as const,
+      properties: {
+        sessionId: { type: 'string' as const },
+      },
+    },
+    body: {
+      type: 'object' as const,
+      required: ['remoteJid', 'presence'],
+      properties: {
+        remoteJid: { type: 'string' as const },
+        presence: { type: 'string' as const, enum: ['composing', 'paused'] },
+      },
+    },
+  },
   sendGroup: {
     tags: ['Messaging'],
     summary: 'Send to group',

--- a/src/controllers/groupController.ts
+++ b/src/controllers/groupController.ts
@@ -7,6 +7,7 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { getSession } from '../services/whatsappService';
 import { Session } from '../models/Session';
+import { sessionStore } from '../services/sessionStore'
 
 // Types
 interface SessionParams {
@@ -521,6 +522,12 @@ export async function updateWebhookHandler(
 
     session.webhook_url = webhook_url || '';
     await session.save();
+
+    const runtime = sessionStore.get(sessionId);
+    
+    if (runtime) {
+      runtime.webhookUrl = session.webhook_url // 🔥 live update
+    }
 
     reply.send({
       success: true,

--- a/src/controllers/sessionController.ts
+++ b/src/controllers/sessionController.ts
@@ -11,6 +11,8 @@ import {
   deleteSession,
   getSessionStatus,
   getSession,
+  markMessageRead,
+  sendPresence,
   sessions,
   qrCodes,
 } from '../services/whatsappService';
@@ -36,6 +38,16 @@ interface SendMessageBody {
     filename?: string;
     mimetype?: string;
   }>;
+}
+
+interface MarkReadBody {
+  remoteJid: string;
+  messageId: string;
+}
+
+interface PresenceBody {
+  remoteJid: string;
+  presence: 'composing' | 'paused';
 }
 
 /**
@@ -471,6 +483,73 @@ export async function sendMessageHandler(
   }
 }
 
+export async function markReadHandler(
+  request: FastifyRequest<{ Params: SessionParams; Body: MarkReadBody }>,
+  reply: FastifyReply
+): Promise<void> {
+  try {
+    const { sessionId } = request.params;
+    const { remoteJid, messageId } = request.body;
+    const user = request.user!;
+
+    if (!remoteJid || !messageId) {
+      reply.status(400).send({ success: false, error: 'Missing remoteJid or messageId' });
+      return;
+    }
+
+    const session = await Session.findOne({ where: { session_id: sessionId, user_id: user.id } });
+    if (!session) {
+      reply.status(404).send({ success: false, error: 'Session not found' });
+      return;
+    }
+
+    await markMessageRead(sessionId, remoteJid, messageId);
+    reply.send({ success: true, message: 'Message marked as read' });
+  } catch (error) {
+    console.error('[Controller] Mark read error:', error);
+    reply.status(500).send({
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}
+
+export async function sendPresenceHandler(
+  request: FastifyRequest<{ Params: SessionParams; Body: PresenceBody }>,
+  reply: FastifyReply
+): Promise<void> {
+  try {
+    const { sessionId } = request.params;
+    const { remoteJid, presence } = request.body;
+    const user = request.user!;
+
+    if (!remoteJid || !presence) {
+      reply.status(400).send({ success: false, error: 'Missing remoteJid or presence' });
+      return;
+    }
+
+    if (presence !== 'composing' && presence !== 'paused') {
+      reply.status(400).send({ success: false, error: 'Invalid presence' });
+      return;
+    }
+
+    const session = await Session.findOne({ where: { session_id: sessionId, user_id: user.id } });
+    if (!session) {
+      reply.status(404).send({ success: false, error: 'Session not found' });
+      return;
+    }
+
+    await sendPresence(sessionId, remoteJid, presence);
+    reply.send({ success: true, message: 'Presence updated' });
+  } catch (error) {
+    console.error('[Controller] Presence error:', error);
+    reply.status(500).send({
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}
+
 export default {
   createSessionHandler,
   getSessionStatusHandler,
@@ -478,4 +557,6 @@ export default {
   deleteSessionHandler,
   listSessionsHandler,
   sendMessageHandler,
+  markReadHandler,
+  sendPresenceHandler,
 };

--- a/src/routes/sessionRoutes.ts
+++ b/src/routes/sessionRoutes.ts
@@ -13,6 +13,8 @@ import {
   deleteSessionHandler,
   listSessionsHandler,
   sendMessageHandler,
+  markReadHandler,
+  sendPresenceHandler,
 } from '../controllers/sessionController';
 import {
   sendToGroupHandler,
@@ -77,6 +79,8 @@ export async function sessionRoutes(
 
   // Send message (text and/or media) to individual
   fastify.post('/session/:sessionId/send', { schema: MessagingSchemas.send }, sendMessageHandler);
+  fastify.post('/session/:sessionId/read', { schema: MessagingSchemas.read }, markReadHandler);
+  fastify.post('/session/:sessionId/presence', { schema: MessagingSchemas.presence }, sendPresenceHandler);
 
   // Send message to group
   fastify.post('/session/:sessionId/send-group', { schema: MessagingSchemas.sendGroup }, sendToGroupHandler);

--- a/src/services/sessionStore.ts
+++ b/src/services/sessionStore.ts
@@ -1,0 +1,4 @@
+// Use State Memory for Hot Reload update The Webhook URL Sessions
+export const sessionStore = new Map<string, {
+      webhookUrl: string
+}>();

--- a/src/services/whatsappService.ts
+++ b/src/services/whatsappService.ts
@@ -96,6 +96,30 @@ export function getSession(sessionId: string): WASocket | undefined {
   return sessions.get(sessionId);
 }
 
+export async function markMessageRead(sessionId: string, remoteJid: string, messageId: string): Promise<void> {
+  const socket = sessions.get(sessionId);
+  if (!socket?.user) {
+    throw new Error('Session not connected');
+  }
+
+  await socket.readMessages([
+    {
+      remoteJid,
+      id: messageId,
+      fromMe: false,
+    },
+  ]);
+}
+
+export async function sendPresence(sessionId: string, remoteJid: string, presence: 'composing' | 'paused'): Promise<void> {
+  const socket = sessions.get(sessionId);
+  if (!socket?.user) {
+    throw new Error('Session not connected');
+  }
+
+  await socket.sendPresenceUpdate(presence, remoteJid);
+}
+
 /**
  * Create a new WhatsApp session
  */

--- a/src/services/whatsappService.ts
+++ b/src/services/whatsappService.ts
@@ -19,6 +19,7 @@ import { AuthKey } from '../models/AuthKey';
 import { env } from '../config/env';
 import QRCode from 'qrcode';
 import pino from 'pino';
+import { sessionStore } from './sessionStore'
 
 // Logger for Baileys (set to silent in production)
 const logger = pino({ level: env.isDev ? 'debug' : 'silent' });
@@ -140,6 +141,10 @@ export async function createSession(
       },
     });
 
+    sessionStore.set(sessionId, {
+      webhookUrl: session.webhook_url
+    });
+
     // If session existed but we are restarting it, update webhook if provided
     if (!created && webhookUrl) {
       session.webhook_url = webhookUrl;
@@ -203,9 +208,12 @@ export async function createSession(
                      msg.message?.stickerMessage),
       }));
 
+
+      const runtime = sessionStore.get(sessionId)
+
       // Send webhook if configured
-      if (session.webhook_url) {
-        await sendWebhook(session.webhook_url, {
+      if (runtime?.webhookUrl) {
+        await sendWebhook(runtime?.webhookUrl, {
           event: 'message.received',
           sessionId,
           timestamp: new Date().toISOString(),
@@ -227,9 +235,11 @@ export async function createSession(
         statusCode: update.update?.status ?? undefined,
       }));
 
+      const runtime = sessionStore.get(sessionId);
+
       // Send webhook if configured
-      if (session.webhook_url) {
-        await sendWebhook(session.webhook_url, {
+      if (runtime?.webhookUrl) {
+        await sendWebhook(runtime?.webhookUrl, {
           event: 'message.status',
           sessionId,
           timestamp: new Date().toISOString(),
@@ -240,8 +250,11 @@ export async function createSession(
 
     // Handle presence updates (online/offline, typing)
     socket.ev.on('presence.update', async (presence) => {
-      if (session.webhook_url) {
-        await sendWebhook(session.webhook_url, {
+      const runtime = sessionStore.get(sessionId)
+
+      // Send webhook if configured
+      if (runtime?.webhookUrl) {
+        await sendWebhook(runtime?.webhookUrl, {
           event: 'presence.update',
           sessionId,
           timestamp: new Date().toISOString(),

--- a/src/services/whatsappService.ts
+++ b/src/services/whatsappService.ts
@@ -11,6 +11,8 @@ import makeWASocket, {
   ConnectionState,
   makeCacheableSignalKeyStore,
   fetchLatestBaileysVersion,
+  jidDecode,
+  jidNormalizedUser,
 } from '@whiskeysockets/baileys';
 import { Boom } from '@hapi/boom';
 import { useSequelizeAuthState } from '../lib/whatsappAuth';
@@ -96,15 +98,35 @@ export function getSession(sessionId: string): WASocket | undefined {
   return sessions.get(sessionId);
 }
 
+function normalizeRemoteJid(remoteJid: string) {
+  const trimmed = remoteJid.trim();
+  if (!trimmed) {
+    throw new Error('Invalid remoteJid');
+  }
+
+  const normalized = trimmed.includes('@')
+    ? jidNormalizedUser(trimmed)
+    : `${trimmed.replace(/[^0-9]/g, '')}@s.whatsapp.net`;
+
+  const decoded = jidDecode(normalized);
+  if (!decoded?.user || !decoded.server) {
+    throw new Error(`Invalid remoteJid: ${remoteJid}`);
+  }
+
+  return normalized;
+}
+
 export async function markMessageRead(sessionId: string, remoteJid: string, messageId: string): Promise<void> {
   const socket = sessions.get(sessionId);
   if (!socket?.user) {
     throw new Error('Session not connected');
   }
 
+  const normalizedRemoteJid = normalizeRemoteJid(remoteJid);
+
   await socket.readMessages([
     {
-      remoteJid,
+      remoteJid: normalizedRemoteJid,
       id: messageId,
       fromMe: false,
     },
@@ -117,7 +139,7 @@ export async function sendPresence(sessionId: string, remoteJid: string, presenc
     throw new Error('Session not connected');
   }
 
-  await socket.sendPresenceUpdate(presence, remoteJid);
+  await socket.sendPresenceUpdate(presence, normalizeRemoteJid(remoteJid));
 }
 
 /**


### PR DESCRIPTION
Fixes #2\n\nI found an issue where the Update Webhook API does not immediately update the webhook used by the runtime API. The webhook URL was stored in a closure that creates a stale reference, so any updates via API were not reflected during runtime.\n\nThis PR adjusts the logic so that the webhook URL is loaded from an in-memory `sessionStore`. This allows updates to take effect immediately without requiring a restart.